### PR TITLE
如果option中有配置的值是函数类型，原先无法正确传入

### DIFF
--- a/WebChart/index.js
+++ b/WebChart/index.js
@@ -26,7 +26,14 @@ export default class WebChart extends React.Component {
     onMessage: () => {},
   }
   componentDidUpdate(prevProps, prevState) {
-    const optionJson = JSON.stringify(this.props.option);
+    // 处理option中函数类型的属性
+    const callback = (key, val) => {
+      if (typeof val === 'function') {
+        return val.toString();
+      }
+      return val;
+    }
+    const optionJson = JSON.stringify(this.props.option, callback);
     if (optionJson !== JSON.stringify(prevProps.option)) {
       this.update(optionJson);
     }
@@ -47,7 +54,13 @@ export default class WebChart extends React.Component {
             const chart = echarts.init(document.getElementById('main'), null, { renderer: 'svg' });
             chart.setOption(${JSON.stringify(this.props.option)});
             document.addEventListener('message', (e) => {
-              chart.setOption(JSON.parse(e.data), true);
+              // 处理可能被字符串处理的option
+              chart.setOption(JSON.parse(e.data, function(key, val) {
+                if (val.indexOf && val.indexOf('function') > -1) {
+                  return eval('(' + val + ')')
+                }
+                return val
+              }), true);
             });
             ${this.props.exScript}
           `}


### PR DESCRIPTION
例如tooltip的formmatter可以接受一个带有data参数的回调函数格式化tooltip，单纯的stringify则会忽略这一回调函数